### PR TITLE
Send the b64_identity field back for use in mq

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -143,6 +143,7 @@ async def handle_file(msgs):
                             'payload_id': data['payload_id'],
                             'account': data['account'],
                             'principal': data['principal'],
+                            'b64_identity': data.get('b64_identity'),
                             'validation': 'success'}
                 }
             )


### PR DESCRIPTION
the avaialble queue might have use of the b64_identity key
so sending it back to upload service for inclusion