### PR TITLE
Allow collection of system profile facts

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -39,12 +39,7 @@ logger = logging.getLogger('advisor-pup')
 # Maxium workers for threaded execution
 MAX_WORKERS = int(os.getenv('MAX_WORKERS', 50))
 
-CANONICAL_FACTS = {
-    'insights-id': Specs.machine_id,
-    'fqdn': Specs.hostname
-}
-
-BUILD_ID = os.getenv('OPENSHIFT_BUILD_COMMIT', 'somemadeupvalue')
+BUILD_ID = os.getenv('OPENSHIFT_BUILD_COMMIT')
 
 INVENTORY_URL = os.getenv('INVENTORY_URL', 'http://inventory:5000/api/hosts')
 
@@ -52,6 +47,8 @@ MQ = os.getenv('KAFKAMQ', 'kafka:29092').split(',')
 MQ_GROUP_ID = os.getenv('MQ_GROUP_ID', 'advisor-pup')
 PUP_QUEUE = os.getenv('PUP_QUEUE', 'platform.upload.pup')
 RETRY_INTERVAL = int(os.getenv('RETRY_INTERVAL', 5))  # seconds
+
+DEVMODE = os.getenv('DEVMODE', False)
 
 
 def get_commit_date(commit_id):
@@ -241,6 +238,9 @@ def main():
 
 
 if __name__ == "__main__":
-    date = get_commit_date(BUILD_ID)
+    if DEVMODE:
+        date = 'devmode'
+    else:
+        date = get_commit_date(BUILD_ID)
     mnm.upload_service_version.info({"version": BUILD_ID, "date": date})
     main()

--- a/pup.py
+++ b/pup.py
@@ -189,6 +189,8 @@ async def post_to_inventory(facts, msg):
     if post.get('metadata'):
         post['facts'].append({'facts': post.pop('metadata'),
                               'namespace': 'insights-client'})
+        post['facts'].append({'facts': post.pop('system_profile'),
+                              'namespace': 'system_profile'})
 
     headers = {'x-rh-identity': post['b64_identity'],
                'Content-Type': 'application/json'}

--- a/pup.py
+++ b/pup.py
@@ -17,10 +17,7 @@ from kafkahelpers import ReconnectingClient
 from prometheus_async.aio import time
 
 from utils import mnm
-from insights import extract
-from insights.util.canonical_facts import get_canonical_facts
-from insights.specs import Specs
-from insights.core.archives import InvalidArchive
+from utils.fact_extract import extract_facts
 
 # Logging
 if any("KUBERNETES" in k for k in os.environ):
@@ -181,18 +178,6 @@ async def validate(url):
         return await extract_facts(temp)
     finally:
         os.remove(temp)
-
-
-async def extract_facts(archive):
-    logger.info("extracting facts from %s", archive)
-    facts = {}
-    try:
-        with extract(archive) as ex:
-            facts = get_canonical_facts(path=ex.tmp_dir)
-    except (InvalidArchive, ModuleNotFoundError, KeyError) as e:
-        facts['error'] = e.args[0]
-
-    return facts
 
 
 @time(mnm.inventory_post_time)

--- a/pup.py
+++ b/pup.py
@@ -183,14 +183,16 @@ async def validate(url):
 @time(mnm.inventory_post_time)
 async def post_to_inventory(facts, msg):
 
+    system_profile = facts.pop('system_profile')
     post = {**facts, **msg}
     post['account'] = post.pop('rh_account')
     post['facts'] = []
     if post.get('metadata'):
         post['facts'].append({'facts': post.pop('metadata'),
                               'namespace': 'insights-client'})
-        post['facts'].append({'facts': post.pop('system_profile'),
-                              'namespace': 'system_profile'})
+
+    post['facts'].append({'facts': system_profile,
+                          'namespace': 'system_profile'})
 
     headers = {'x-rh-identity': post['b64_identity'],
                'Content-Type': 'application/json'}

--- a/utils/fact_extract.py
+++ b/utils/fact_extract.py
@@ -1,11 +1,135 @@
 import logging
+import ipaddress
+from ipaddress import AddressValueError
+
 from insights import extract, rule, make_metadata, run
-from insights.util.canonical_facts import get_canonical_facts
+
 from insights.core.archives import InvalidArchive
+from insights.parsers.dmidecode import DMIDecode
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.parsers.lsmod import LsMod
+from insights.parsers.meminfo import MemInfo
+from insights.parsers.redhat_release import RedhatRelease
+from insights.parsers.uname import Uname
+from insights.parsers.systemd.unitfiles import UnitFiles
+from insights.parsers.virt_what import VirtWhat
 from insights.specs import Specs
+from insights.util.canonical_facts import get_canonical_facts, IPs
 
 logger = logging.getLogger('advisor-pup')
 
+
+@rule(optional=[Specs.hostname, Specs.lscpu, VirtWhat, MemInfo, IPs, DMIDecode, RedhatRelease, Uname, LsMod, InstalledRpms, UnitFiles])
+def system_profile_facts(hostname, lscpu, virt_what, meminfo, ips, dmidecode, redhat_release, uname, lsmod, installed_rpms, unit_files):
+    """
+    System Properties:
+      hostnames (list of just fqdn for now)
+      mem in GB
+    Infrastructure:
+      infrastructure_type (phys or virt)
+      infrastructure vendor (hypervisor type)
+      IPv4 addresses (list)
+      IPv6 addresses (list)
+    BIOS:
+      Vendor
+      Version
+      Release Date
+    Operating System:
+      Release (RHEL/Fedora)
+      Kernel Version
+      Kernel Release
+      Arch
+      Kernel Modules (list)
+    Configuration
+      Services
+    """
+    metadata_args = {}
+
+    metadata_args['system_properties.hostnames'] = [_safe_parse(hostname)]
+    metadata_args['system_properties.memory_in_gb'] = bytes_to_gb(meminfo.total) if meminfo else None
+
+    metadata_args['infrastructure.type'] = _get_virt_phys_fact(virt_what)
+    metadata_args['infrastructure.vendor'] = virt_what.generic if virt_what else None
+
+    if ips:
+        ip_addresses = ipv4_ipv6_addresses(ips.data)
+        metadata_args['infrastructure.ipv4_addresses'] = ip_addresses.get('ipv4')
+        metadata_args['infrastructure.ipv4_addresses'] = ip_addresses.get('ipv6')
+
+    metadata_args['bios.vendor'] = dmidecode.bios_vendor if dmidecode else None
+    metadata_args['bios.version'] = dmidecode.bios.get('version') if dmidecode else None
+    # note that this is a date and not a datetime, hence no full iso8601
+    metadata_args['bios.release_date'] = dmidecode.bios_date.isoformat() if dmidecode else None
+
+    metadata_args['os.release'] = redhat_release.product if redhat_release else None
+    metadata_args['os.kernel_version'] = uname.version if uname else None
+    metadata_args['os.kernel_release'] = uname.release if uname else None
+    metadata_args['os.arch'] = uname.arch if uname else None
+    metadata_args['os.kernel_modules'] = list(lsmod.data.keys()) if lsmod else []  # convert for json serialization
+
+    metadata_args['configuration.services'] = _create_services_fact(unit_files)
+
+    return make_metadata(**metadata_args)
+
+
+def _get_virt_phys_fact(virt_what):
+    if virt_what.is_virtual:
+        return 'virtual'
+    elif virt_what.is_physical:
+        return 'physical'
+    else:
+        return None
+
+
+def _create_services_fact(unit_files):
+    """
+    create a json serializable dict of services. The key is the service name,
+    and the value is if it's enabled or not.
+    """
+    services = {}
+    for service in unit_files.services:
+        if service.endswith('.service'):
+            services.update({service: unit_files.services[service]})
+
+    return services
+
+
+def test_ipv4_addr(address):
+    """
+    return true if address is ipv4, false otherwise
+    """
+    try:
+        ipaddress.IPv4Address(address)
+        return True
+    except AddressValueError:
+        return False
+
+
+def test_ipv6_addr(address):
+    """
+    return true if address is ipv6, false otherwise
+    """
+    try:
+        ipaddress.IPv6Address(address)
+        return True
+    except AddressValueError:
+        return False
+
+
+def ipv4_ipv6_addresses(addresses):
+    """
+    return a dict with IPv4 and IPv6 addresses
+    """
+    result = {'ipv4_addresses': [a for a in addresses if test_ipv4_addr(a)],
+              'ipv6_addresses': [a for a in addresses if test_ipv6_addr(a)]}
+    return result
+
+
+def bytes_to_gb(num_bytes):
+    return '%.1f' % float(num_bytes / 1_000_000_000) + " GB"
+
+
+# from insights-core get_canonical_facts util
 def _safe_parse(ds):
     try:
         return ds.content[0]
@@ -13,17 +137,12 @@ def _safe_parse(ds):
     except Exception:
         return None
 
-@rule(optional=[Specs.meminfo])
-def system_profile_facts(meminfo):
-    return make_metadata(
-        meminfo=_safe_parse(meminfo)
-    )
 
 def get_system_profile_facts(path=None):
-    br = run(system_profile_facts, root=path)
-    d = br[system_profile_facts]
-    del d["type"]
-    return d
+    broker = run(system_profile_facts, root=path)
+    result = broker[system_profile_facts]
+    del result["type"]  # drop metadata key
+    return result
 
 
 async def extract_facts(archive):

--- a/utils/fact_extract.py
+++ b/utils/fact_extract.py
@@ -1,0 +1,39 @@
+import logging
+from insights import extract, rule, make_metadata, run
+from insights.util.canonical_facts import get_canonical_facts
+from insights.core.archives import InvalidArchive
+from insights.specs import Specs
+
+logger = logging.getLogger('advisor-pup')
+
+def _safe_parse(ds):
+    try:
+        return ds.content[0]
+
+    except Exception:
+        return None
+
+@rule(optional=[Specs.meminfo])
+def system_profile_facts(meminfo):
+    return make_metadata(
+        meminfo=_safe_parse(meminfo)
+    )
+
+def get_system_profile_facts(path=None):
+    br = run(system_profile_facts, root=path)
+    d = br[system_profile_facts]
+    del d["type"]
+    return d
+
+
+async def extract_facts(archive):
+    logger.info("extracting facts from %s", archive)
+    facts = {}
+    try:
+        with extract(archive) as ex:
+            facts = get_canonical_facts(path=ex.tmp_dir)
+            facts['system_profile'] = get_system_profile_facts(path=ex.tmp_dir)
+    except (InvalidArchive, ModuleNotFoundError, KeyError) as e:
+        facts['error'] = e.args[0]
+
+    return facts


### PR DESCRIPTION
We would like to collect "system profile" facts. These are different than
canonical facts since they are not used to identify a machine.

This commit adds "system_profile" to the facts hash and sends it into inventory
service. For now, the additional facts are placed under the `system_profile`
namespace.