### PR TITLE
fix CPU flag reading

### DIFF
--- a/pup/utils/fact_extract.py
+++ b/pup/utils/fact_extract.py
@@ -6,6 +6,7 @@ from insights import extract, rule, make_metadata, run
 
 from insights.core.archives import InvalidArchive
 from insights.parsers.dmidecode import DMIDecode
+from insights.parsers.cpuinfo import CpuInfo
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.parsers.lsmod import LsMod
 from insights.parsers.meminfo import MemInfo
@@ -19,8 +20,8 @@ from insights.util.canonical_facts import get_canonical_facts, IPs
 logger = logging.getLogger('advisor-pup')
 
 
-@rule(optional=[Specs.hostname, Specs.lscpu, VirtWhat, MemInfo, IPs, DMIDecode, RedhatRelease, Uname, LsMod, InstalledRpms, UnitFiles])
-def system_profile_facts(hostname, lscpu, virt_what, meminfo, ips, dmidecode, redhat_release, uname, lsmod, installed_rpms, unit_files):
+@rule(optional=[Specs.hostname, CpuInfo, VirtWhat, MemInfo, IPs, DMIDecode, RedhatRelease, Uname, LsMod, InstalledRpms, UnitFiles])
+def system_profile_facts(hostname, cpu_info, virt_what, meminfo, ips, dmidecode, redhat_release, uname, lsmod, installed_rpms, unit_files):
     """
     System Properties:
       hostnames (list of just fqdn for now)
@@ -34,6 +35,7 @@ def system_profile_facts(hostname, lscpu, virt_what, meminfo, ips, dmidecode, re
       Vendor
       Version
       Release Date
+    CPU Flags
     Operating System:
       Release (RHEL/Fedora)
       Kernel Version
@@ -60,6 +62,7 @@ def system_profile_facts(hostname, lscpu, virt_what, meminfo, ips, dmidecode, re
     metadata_args['bios.version'] = dmidecode.bios.get('version') if dmidecode else None
     # note that this is a date and not a datetime, hence no full iso8601
     metadata_args['bios.release_date'] = dmidecode.bios_date.isoformat() if dmidecode else None
+    metadata_args['cpu_flags'] = cpu_info.flags if cpu_info else None
 
     metadata_args['os.release'] = redhat_release.product if redhat_release else None
     metadata_args['os.kernel_version'] = uname.version if uname else None


### PR DESCRIPTION
Previously we attempted to pull CPU flags from the lscpu output, which is not
typically populated.

Instead, use the CpuInfo parser to read the CPU flags.