### PR TITLE
strip empty values before posting to inv svc

### DIFF
--- a/pup/utils/fact_extract.py
+++ b/pup/utils/fact_extract.py
@@ -142,6 +142,14 @@ def _safe_parse(ds):
         return None
 
 
+def _strip_empty_facts(facts):
+    defined_facts = {}
+    for fact in facts:
+        if facts[fact]:
+            defined_facts.update({fact: facts[fact]})
+    return defined_facts
+
+
 def get_system_profile_facts(path=None):
     broker = run(system_profile_facts, root=path)
     result = broker[system_profile_facts]
@@ -159,4 +167,4 @@ def extract_facts(archive):
     except (InvalidArchive, ModuleNotFoundError, KeyError, CalledProcessError) as e:
         facts['error'] = e.args[0]
 
-    return facts
+    return _strip_empty_facts(facts)


### PR DESCRIPTION
The inventory service has additional validations on fields like
`bios_uuid` and `ip_addresses`, and no longer allows `None` and `[]`.

If we do not have data in these fields, we need to strip them out
before POSTing.