### PR TITLE
break out consumer and producer from `pup.py`.

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -27,6 +27,7 @@ else:
 
 logger = logging.getLogger('advisor-pup')
 
+
 def main():
     produce_queue = collections.deque([], 999)
     thread_pool_executor = ThreadPoolExecutor(max_workers=configuration.MAX_WORKERS)

--- a/pup.py
+++ b/pup.py
@@ -3,21 +3,15 @@ import os
 import sys
 import asyncio
 import collections
-import json
-import aiohttp
 
-from tempfile import NamedTemporaryFile
-from aiohttp.client_exceptions import ClientConnectionError, ServerDisconnectedError
 from logstash_formatter import LogstashFormatterV1
 from concurrent.futures import ThreadPoolExecutor
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
-from kafka.errors import KafkaError
 from kafkahelpers import ReconnectingClient
-from prometheus_async.aio import time
 
+from pup.client_context import ClientContext
 from pup.utils import mnm, configuration
-from pup.utils.fact_extract import extract_facts
-from pup.utils.get_commit_date import get_commit_date
+from pup.utils.get_version_info import get_version_info
 
 # Logging
 if any("KUBERNETES" in k for k in os.environ):
@@ -34,204 +28,34 @@ else:
 logger = logging.getLogger('advisor-pup')
 
 
-thread_pool_executor = ThreadPoolExecutor(max_workers=configuration.MAX_WORKERS)
-loop = asyncio.get_event_loop()
-
-kafka_consumer = AIOKafkaConsumer(
-    configuration.PUP_QUEUE, loop=loop, bootstrap_servers=configuration.MQ,
-    group_id=configuration.MQ_GROUP_ID
-)
-kafka_producer = AIOKafkaProducer(
-    loop=loop, bootstrap_servers=configuration.MQ, request_timeout_ms=10000,
-    connections_max_idle_ms=None
-)
-
-CONSUMER = ReconnectingClient(kafka_consumer, "consumer")
-PRODUCER = ReconnectingClient(kafka_producer, "producer")
-
-# local queue for pushing items into kafka, this queue fills up if kafka goes down
-produce_queue = collections.deque([], 999)
-
-
-async def consume(client):
-    data = await client.getmany()
-    for tp, msgs in data.items():
-        if tp.topic == configuration.PUP_QUEUE:
-            logger.info("received messages: %s", msgs)
-            loop.create_task(handle_file(msgs))
-    await asyncio.sleep(0.1)
-
-
-def fail_upload(data, response):
-    mnm.invalid.inc()
-    logger.info("payload_id [%s] validation failed with error: %s", data['payload_id'], response['error'])
-    data_to_produce = {
-        'topic': 'platform.upload.validation',
-        'msg': {
-            'payload_id': data['payload_id'],
-            'validation': 'failure'
-        }
-    }
-    return data_to_produce
-
-
-def succeed_upload(data, response):
-    mnm.valid.inc()
-    logger.info("payload_id [%s] validation successful", data['payload_id'])
-    data_to_produce = {
-        'topic': 'platform.upload.validation',
-        'msg': {
-            'id': response.get('id') if response else None,
-            'service': data['service'],
-            'payload_id': data['payload_id'],
-            'account': data['account'],
-            'principal': data['principal'],
-            'b64_identity': data.get('b64_identity'),
-            'validation': 'success'
-        }
-    }
-    return data_to_produce
-
-
-async def handle_file(msgs):
-    for msg in msgs:
-        try:
-            data = json.loads(msg.value)
-        except ValueError:
-            logger.error("handle_file(): unable to decode msg as json: {}".format(msg.value))
-            continue
-
-        logger.info(data)
-        machine_id = data['metadata'].get('machine_id') if data.get('metadata') else None
-        mnm.total.inc()
-        try:
-            result = await validate(data['url'])
-        except (ServerDisconnectedError, ClientConnectionError):
-            logger.error('Connection to S3 Failed')
-            continue
-
-        if len(result) > 0 and 'error' not in result:
-            if result.get('insights_id') != machine_id:
-                response = await post_to_inventory(result, data)
-            else:
-                response = {"id": result.get('insights_id')}
-
-            if response.get('error'):
-                data_to_produce = fail_upload(data, response)
-            else:
-                data_to_produce = succeed_upload(data, response)
-
-        else:
-            data_to_produce = fail_upload(data, result)
-
-        produce_queue.append(data_to_produce)
-        logger.info(
-            "data for topic [%s], payload_id [%s] put on produce queue (qsize now: %d): %s",
-            data_to_produce['topic'], data_to_produce['msg']['payload_id'], len(produce_queue), data_to_produce
-        )
-
-
-def make_producer(queue=None):
-    queue = produce_queue if queue is None else queue
-
-    async def send_result(client):
-        if not queue:
-            await asyncio.sleep(0.1)
-        else:
-            item = queue.popleft()
-            topic, msg, payload_id = item['topic'], item['msg'], item['msg'].get('payload_id')
-            logger.info(
-                "Popped data from produce queue (qsize now: %d) for topic [%s], payload_id [%s]: %s",
-                len(queue), topic, payload_id, msg
-            )
-            try:
-                await client.send_and_wait(topic, json.dumps(msg).encode("utf-8"))
-                logger.info("send data for topic [%s] with payload_id [%s] succeeded", topic, payload_id)
-            except KafkaError:
-                queue.append(item)
-                logger.error(
-                    "send data for topic [%s] with payload_id [%s] failed, put back on queue (qsize now: %d)",
-                    topic, payload_id, len(queue)
-                )
-                raise
-    return send_result
-
-
-@time(mnm.validation_time)
-async def validate(url):
-
-    temp = NamedTemporaryFile(delete=False).name
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
-            open(temp, 'wb').write(await response.read())
-        await session.close()
-
-    try:
-        return await loop.run_in_executor(None, extract_facts, temp)
-    finally:
-        os.remove(temp)
-
-
-@time(mnm.inventory_post_time)
-async def post_to_inventory(facts, msg):
-
-    post = {**facts, **msg}
-    post['account'] = post.pop('rh_account')
-    post['facts'] = []
-    if post.get('metadata'):
-        post['facts'].append({'facts': post.pop('metadata'),
-                              'namespace': 'insights-client'})
-
-    headers = {'x-rh-identity': post['b64_identity'],
-               'Content-Type': 'application/json'}
-
-    try:
-        timeout = aiohttp.ClientTimeout(total=60)
-        async with aiohttp.ClientSession() as session:
-            async with session.post(configuration.INVENTORY_URL, data=json.dumps([post]), headers=headers, timeout=timeout) as response:
-                response_json = await response.json()
-                if response.status != 207:
-                    error = response_json.get('detail')
-                    logger.error('Failed to post to inventory: %s', error)
-                    return {"error": "Failed to post to inventory."}
-                elif response_json['data'][0]['status'] != 200 and response_json['data'][0]['status'] != 201:
-                    mnm.inventory_post_failure.inc()
-                    logger.error(
-                        'payload_id [%s] failed to post to inventory.', msg['payload_id']
-                    )
-                    logger.debug(
-                        'inventory error response: %s', await response.text()
-                    )
-                    return {"error": "Failed to post to inventory."}
-                else:
-                    mnm.inventory_post_success.inc()
-                    logger.info("payload_id [%s] posted to inventory: ID [%s]",
-                                msg['payload_id'],
-                                response_json['data'][0]['host']['id'])
-                    return response_json['data'][0]['host']
-            await session.close()
-
-    except ClientConnectionError as e:
-        logger.error("payload_id [%s] failed to post to inventory, unable to connect: %s", msg['payload_id'], e)
-        return {"error": "Unable to update inventory. Service unavailable"}
-
-
 def main():
+    produce_queue = collections.deque([], 999)
+    thread_pool_executor = ThreadPoolExecutor(max_workers=configuration.MAX_WORKERS)
+    loop = asyncio.get_event_loop()
+    client_context = ClientContext(produce_queue, loop)
+
+    kafka_consumer = AIOKafkaConsumer(
+        configuration.PUP_QUEUE, loop=loop, bootstrap_servers=configuration.MQ,
+        group_id=configuration.MQ_GROUP_ID
+    )
+    kafka_producer = AIOKafkaProducer(
+        loop=loop, bootstrap_servers=configuration.MQ, request_timeout_ms=10000,
+        connections_max_idle_ms=None
+    )
+
+    reconnecting_consumer = ReconnectingClient(kafka_consumer, "consumer")
+    reconnecting_producer = ReconnectingClient(kafka_producer, "producer")
+
     try:
         mnm.start_http_server(port=9126)
         loop.set_default_executor(thread_pool_executor)
-        loop.create_task(CONSUMER.get_callback(consume)())
-        loop.create_task(PRODUCER.get_callback(make_producer(produce_queue))())
+        loop.create_task(reconnecting_consumer.get_callback(client_context.consume)())
+        loop.create_task(reconnecting_producer.get_callback(client_context.send_result)())
         loop.run_forever()
     except KeyboardInterrupt:
         loop.stop()
 
 
 if __name__ == "__main__":
-    if configuration.DEVMODE:
-        date = 'devmode'
-    else:
-        date = get_commit_date(configuration.BUILD_ID)
-    mnm.upload_service_version.info({"version": configuration.BUILD_ID, "date": date})
+    mnm.upload_service_version.info(get_version_info())
     main()

--- a/pup/client_context.py
+++ b/pup/client_context.py
@@ -1,0 +1,54 @@
+import logging
+import asyncio
+import json
+
+from kafka.errors import KafkaError
+
+from pup.utils import configuration
+from pup.consumer import handle_file
+
+
+logger = logging.getLogger('advisor-pup')
+
+
+class ClientContext():
+    """
+    This class exists to keep shared state in `produce_queue` between the
+    consume and send_result methods. It also has the coroutines for the PUP
+    consumer and producer.
+    """
+
+    def __init__(self, produce_queue, loop):
+        # local queue for pushing items into kafka, this queue fills up if kafka
+        # goes down
+        self.produce_queue = produce_queue
+        self.loop = loop
+
+    async def consume(self, client):
+        data = await client.getmany()
+        for tp, msgs in data.items():
+            if tp.topic == configuration.PUP_QUEUE:
+                logger.info("received messages: %s", msgs)
+                self.loop.create_task(handle_file(msgs, self.produce_queue))
+        await asyncio.sleep(0.1)
+
+    async def send_result(self, client):
+        if not self.produce_queue:
+            await asyncio.sleep(0.1)
+        else:
+            item = self.produce_queue.popleft()
+            topic, msg, payload_id = item['topic'], item['msg'], item['msg'].get('payload_id')
+            logger.info(
+                "Popped data from produce queue (qsize now: %d) for topic [%s], payload_id [%s]: %s",
+                len(self.produce_queue), topic, payload_id, msg
+            )
+            try:
+                await client.send_and_wait(topic, json.dumps(msg).encode("utf-8"))
+                logger.info("send data for topic [%s] with payload_id [%s] succeeded", topic, payload_id)
+            except KafkaError:
+                self.produce_queue.append(item)
+                logger.error(
+                    "send data for topic [%s] with payload_id [%s] failed, put back on queue (qsize now: %d)",
+                    topic, payload_id, len(self.produce_queue)
+                )
+                raise

--- a/pup/consumer.py
+++ b/pup/consumer.py
@@ -1,0 +1,145 @@
+import aiohttp
+import asyncio
+import json
+import logging
+import os
+
+from tempfile import NamedTemporaryFile
+from aiohttp.client_exceptions import ClientConnectionError, ServerDisconnectedError
+from prometheus_async.aio import time
+
+from pup.utils import mnm, configuration
+from pup.utils.fact_extract import extract_facts
+
+logger = logging.getLogger('advisor-pup')
+
+
+def fail_upload(data, response):
+    mnm.invalid.inc()
+    logger.info("payload_id [%s] validation failed with error: %s", data['payload_id'], response['error'])
+    data_to_produce = {
+        'topic': 'platform.upload.validation',
+        'msg': {
+            'payload_id': data['payload_id'],
+            'validation': 'failure'
+        }
+    }
+    return data_to_produce
+
+
+def succeed_upload(data, response):
+    mnm.valid.inc()
+    logger.info("payload_id [%s] validation successful", data['payload_id'])
+    data_to_produce = {
+        'topic': 'platform.upload.validation',
+        'msg': {
+            'id': response.get('id') if response else None,
+            'service': data['service'],
+            'payload_id': data['payload_id'],
+            'account': data['account'],
+            'principal': data['principal'],
+            'b64_identity': data.get('b64_identity'),
+            'validation': 'success'
+        }
+    }
+    return data_to_produce
+
+
+async def handle_file(msgs, produce_queue):
+
+    for msg in msgs:
+        try:
+            data = json.loads(msg.value)
+        except ValueError:
+            logger.error("handle_file(): unable to decode msg as json: {}".format(msg.value))
+            continue
+
+        logger.info(data)
+        machine_id = data['metadata'].get('machine_id') if data.get('metadata') else None
+        mnm.total.inc()
+        try:
+            result = await validate(data['url'])
+        except (ServerDisconnectedError, ClientConnectionError):
+            logger.error('Connection to S3 Failed')
+            continue
+
+        if len(result) > 0 and 'error' not in result:
+            if result.get('insights_id') != machine_id:
+                response = await post_to_inventory(result, data)
+            else:
+                response = {"id": result.get('insights_id')}
+
+            if response.get('error'):
+                data_to_produce = fail_upload(data, response)
+            else:
+                data_to_produce = succeed_upload(data, response)
+
+        else:
+            data_to_produce = fail_upload(data, result)
+
+        produce_queue.append(data_to_produce)
+        logger.info(
+            "data for topic [%s], payload_id [%s] put on produce queue (qsize now: %d): %s",
+            data_to_produce['topic'], data_to_produce['msg']['payload_id'], len(produce_queue), data_to_produce
+        )
+
+
+@time(mnm.validation_time)
+async def validate(url):
+
+    temp = NamedTemporaryFile(delete=False).name
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            open(temp, 'wb').write(await response.read())
+        await session.close()
+
+    try:
+        # _get_running_loop was renamed to get_running_loop in py3.7
+        loop = asyncio._get_running_loop()
+        return await loop.run_in_executor(None, extract_facts, temp)
+    finally:
+        os.remove(temp)
+
+
+@time(mnm.inventory_post_time)
+async def post_to_inventory(facts, msg):
+
+    post = {**facts, **msg}
+    post['account'] = post.pop('rh_account')
+    post['facts'] = []
+    if post.get('metadata'):
+        post['facts'].append({'facts': post.pop('metadata'),
+                              'namespace': 'insights-client'})
+
+    headers = {'x-rh-identity': post['b64_identity'],
+               'Content-Type': 'application/json'}
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=60)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(configuration.INVENTORY_URL, data=json.dumps([post]), headers=headers, timeout=timeout) as response:
+                response_json = await response.json()
+                if response.status != 207:
+                    error = response_json.get('detail')
+                    logger.error('Failed to post to inventory: %s', error)
+                    return {"error": "Failed to post to inventory."}
+                elif response_json['data'][0]['status'] != 200 and response_json['data'][0]['status'] != 201:
+                    mnm.inventory_post_failure.inc()
+                    logger.error(
+                        'payload_id [%s] failed to post to inventory.', msg['payload_id']
+                    )
+                    logger.debug(
+                        'inventory error response: %s', await response.text()
+                    )
+                    return {"error": "Failed to post to inventory."}
+                else:
+                    mnm.inventory_post_success.inc()
+                    logger.info("payload_id [%s] posted to inventory: ID [%s]",
+                                msg['payload_id'],
+                                response_json['data'][0]['host']['id'])
+                    return response_json['data'][0]['host']
+            await session.close()
+    except ClientConnectionError as e:
+        logger.error("payload_id [%s] failed to post to inventory, unable to connect: %s", msg['payload_id'], e)
+        return {"error": "Unable to update inventory. Service unavailable"}

--- a/pup/utils/fact_extract.py
+++ b/pup/utils/fact_extract.py
@@ -27,6 +27,7 @@ SATELLITE_MANAGED_FILES = {
     "sat6": ["/etc/rhsm/ca", "katello-server-ca.pem"],
 }
 
+
 @rule(optional=[Specs.hostname, CpuInfo, VirtWhat, MemInfo, IpAddr, DMIDecode,
                 RedhatRelease, Uname, LsMod, InstalledRpms, UnitFiles, PsAuxcww,
                 DateUTC, Uptime, YumReposD, LsEtc])

--- a/pup/utils/get_commit_date.py
+++ b/pup/utils/get_commit_date.py
@@ -1,9 +1,0 @@
-import requests
-
-COMMIT_BASE_URL = "https://api.github.com/repos/RedHatInsights/insights-pup/git/commits/"
-
-
-def get_commit_date(commit_id):
-    url = COMMIT_BASE_URL + commit_id
-    response = requests.get(url).json()
-    return response['committer']['date']

--- a/pup/utils/get_version_info.py
+++ b/pup/utils/get_version_info.py
@@ -1,0 +1,21 @@
+import requests
+
+from pup.utils import configuration
+
+COMMIT_BASE_URL = "https://api.github.com/repos/RedHatInsights/insights-pup/git/commits/"
+
+
+def get_commit_date(commit_id):
+    url = COMMIT_BASE_URL + commit_id
+    response = requests.get(url).json()
+    return response['committer']['date']
+
+
+def get_version_info():
+    if configuration.DEVMODE:
+        date = 'devmode'
+    elif configuration.BUILD_ID:
+        date = get_commit_date(configuration.BUILD_ID)
+    else:
+        raise "OPENSHIFT_BUILD_COMMIT or DEVMODE not set"
+    return {"version": configuration.BUILD_ID, "date": date}

--- a/tests/test_get_version_info.py
+++ b/tests/test_get_version_info.py
@@ -2,10 +2,10 @@ import requests
 import responses
 import unittest
 
-from pup.utils.get_commit_date import get_commit_date
+from pup.utils.get_version_info import get_commit_date
 
 
-class GetCommitDateTests(unittest.TestCase):
+class GetVersionInfoTests(unittest.TestCase):
 
     @responses.activate
     def test_get_commit_date(self):


### PR DESCRIPTION
Previously, the kafka consumer and producer were in `pup.py`. This commit moves
them into ClientContext, a small class that also maintains the producer queue.

The consumer's methods have been moved to `consumer.py`.

Finally, `get_commit_date` was moved to `get_version_info`, which assembles the
dict that mnm needs.