### PR TITLE
Convert handle_file to a task

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -58,7 +58,7 @@ async def consume(client):
     for tp, msgs in data.items():
         if tp.topic == configuration.PUP_QUEUE:
             logger.info("received messages: %s", msgs)
-            await handle_file(msgs)
+            loop.create_task(handle_file(msgs))
     await asyncio.sleep(0.1)
 
 


### PR DESCRIPTION
Need to do this to allow handle_file to be converted to a coroutine so
that it gets out of the way and we can grab more messages

this change should allow our pods to process the max amount of messages they can at a time rather than only doing chunks. We should scale with this change in place