### PR TITLE
add more defensive parsing and remove 64KB limit

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -183,7 +183,10 @@ async def post_to_inventory(facts, msg):
                 elif response_json['data'][0]['status'] != 200 and response_json['data'][0]['status'] != 201:
                     mnm.inventory_post_failure.inc()
                     logger.error(
-                        'payload_id [%s] failed to post to inventory: %s', msg['payload_id'], await response.text()
+                        'payload_id [%s] failed to post to inventory.', msg['payload_id']
+                    )
+                    logger.debug(
+                        'inventory error response: %s', await response.text()
                     )
                 else:
                     mnm.inventory_post_success.inc()


### PR DESCRIPTION
This commit does four things:

 * removes 64KB size limit when parsing system profile

 * remove empty fields off of yum repo definition so inventory service
   will accept them. Not all repos have a `base_url`.

 * parses network interfaces more defensively. For example, bridge
   interfaces do not have MACs.

 * do not log entire reponse from inventory service on failed POST
   unless `LOGLEVEL=DEBUG`. Especially with the removal of the 64KB limit,
   the log from a failed POST can be large. Now we just log that a failure
   occurred but do not log the full message with request by default.