### PR TITLE
Do not try to log the request_id and account number when parsing the json message fails

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -122,9 +122,8 @@ async def handle_file(msgs):
     for msg in msgs:
         try:
             data = json.loads(msg.value)
-        except ValueError:
-            logger.error("handle_file(): unable to decode msg as json: %s", msg.value, extra={"request_id": data['payload_id'],
-                                                                                              "account": data["account"]})
+        except Exception:
+            logger.exception("handle_file(): unable to decode msg as json: %s", msg.value)
             continue
 
         mnm.total.inc()


### PR DESCRIPTION
Modify the log message so that it does not pull the request_id and account number from the data object.  The data object is likely invalid if the json failed to parse.

@SteveHNH I did not test this (sorry...).  To me, it looks like this log message could result in an unhandled exception if the json fails to parse.  I'm not sure what that means to the thread that is handling the event loop.

I also changed the except clause to catch the top level Exception.  It looks like json.loads() will throw a TypeError if it gets sent something that doesn't look like a string.  I figure in this case its better to "cast a wider" net...log the error and move on.

Feel free to ignore this PR if I'm looking at things wrong.