### PR TITLE
Simplify extra

### DIFF
--- a/pup/utils/fact_extract.py
+++ b/pup/utils/fact_extract.py
@@ -210,24 +210,21 @@ def get_system_profile(path=None):
     return result
 
 
-def extract_facts(archive, request_id, account, remove=True):
+def extract_facts(archive, request_id, account, extra, remove=True):
     # TODO: facts, system_profiles, and errors are all passed through via the
     # 'facts' hash. These should likely be split out.
-    logger.info("extracting facts from %s", archive, extra={"request_id": request_id,
-                                                            "account": account})
+    logger.info("extracting facts from %s", archive, extra=extra)
     facts = {}
     try:
         with extract(archive) as ex:
             facts = get_canonical_facts(path=ex.tmp_dir)
             facts['system_profile'] = get_system_profile(path=ex.tmp_dir)
     except Exception as e:
-        logger.exception("Failed to extract facts: %s", e, extra={"request_id": request_id,
-                                                                  "account": account})
+        logger.exception("Failed to extract facts: %s", e, extra=extra)
         facts['error'] = e
 
     groomed_facts = _remove_empties(_remove_bad_display_name(facts))
     if remove:
         os.remove(archive)
-    logger.info("Successfully extracted canonical facts", extra={"request_id": request_id,
-                                                                 "account": account})
+    logger.info("Successfully extracted canonical facts", extra=extra)
     return groomed_facts

--- a/pup/utils/fact_extract.py
+++ b/pup/utils/fact_extract.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from insights.core import dr
 from insights import extract, rule, make_metadata, run
 
 from insights.combiners.cloud_provider import CloudProvider
@@ -23,6 +24,7 @@ from insights.specs import Specs
 from insights.util.canonical_facts import get_canonical_facts
 
 logger = logging.getLogger('advisor-pup')
+dr.log.setLevel("ERROR")
 
 SATELLITE_MANAGED_FILES = {
     "sat5": ["/etc/sysconfig/rhn", "systemid"],


### PR DESCRIPTION
Instead of trying to add request_id and account to every log manually, create a get_extra function that can establish these fields in a more straightforward way.

Also reduce the logging for system_profile fact extraction significantly.