### PR TITLE
validate could return a None

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -158,6 +158,10 @@ async def handle_file(msgs):
             logger.exception("Validation encountered error: %s", e, extra=extra)
             continue
 
+        if result is None:
+            logger.info("Validation resulted in a None...ignoring msg", extra=extra)
+            continue
+
         # we do not want to POST the system profile to inventory
         # until after we get an id
         system_profile = result.pop("system_profile")


### PR DESCRIPTION
The validate method could return None in the case of an exception happening during the download.  Check to see if the result is None before trying to use it.  If a None is returned by the validate method, the pop will blowout in which case the rest of the messages in msgs will not get processed.

An alternative to this would be to re-raise the exception in validate.  Might need to add more exception handling within the "for msg in msgs" block.

This None check might also be required if the fact extraction can return a None.

I have not thoroughly tested this...so make sure I haven't messed something up with this change.  :)