### PR TITLE
Do not let failing to determine the commit date, cause the application to fail to start

### DIFF
--- a/pup.py
+++ b/pup.py
@@ -360,9 +360,6 @@ def main():
 
 
 if __name__ == "__main__":
-    if configuration.DEVMODE:
-        date = 'devmode'
-    else:
-        date = get_commit_date(configuration.BUILD_ID)
+    date = get_commit_date(configuration.BUILD_ID)
     mnm.upload_service_version.info({"version": configuration.BUILD_ID, "date": date})
     main()

--- a/pup/utils/configuration.py
+++ b/pup/utils/configuration.py
@@ -1,7 +1,7 @@
 import os
 
 # Maximum workers for threaded execution
-BUILD_ID = os.getenv('OPENSHIFT_BUILD_COMMIT')
+BUILD_ID = os.getenv('OPENSHIFT_BUILD_COMMIT', "unknown")
 DEVMODE = os.getenv('DEVMODE', False)
 INVENTORY_URL = os.getenv('INVENTORY_URL', 'http://inventory:5000/api/hosts')
 MAX_WORKERS = int(os.getenv('MAX_WORKERS', 50))

--- a/pup/utils/get_commit_date.py
+++ b/pup/utils/get_commit_date.py
@@ -1,9 +1,18 @@
+import logging
 import requests
 
 COMMIT_BASE_URL = "https://api.github.com/repos/RedHatInsights/insights-pup/git/commits/"
 
+logger = logging.getLogger('advisor-pup')
+
 
 def get_commit_date(commit_id):
     url = COMMIT_BASE_URL + commit_id
-    response = requests.get(url).json()
-    return response['committer']['date']
+    try:
+        response = requests.get(url, timeout=0.5).json()
+        return response['committer']['date']
+    except Exception:
+        # Log the exception and keep going.  Do not let failing to
+        # determine the commit date stop the process from starting.
+        logger.exception("Error retrieving commit date from github")
+        return "unknown"


### PR DESCRIPTION
This commit adds a timeout to the http call that retrieves the commit date and adds a bit more error handling around the retrieval of the commit date.  We don't want a network hiccup,  a change in the url or formatting of the github response to cause pup to fail to start.

@SteveHNH this is just a suggestion.  Feel free to adjust the code as you see fit or ignore me.  :)