### PR TITLE
Add installed_products to system profile

### DIFF
--- a/pup/utils/fact_extract.py
+++ b/pup/utils/fact_extract.py
@@ -12,6 +12,7 @@ from insights.combiners.virt_what import VirtWhat
 from insights.parsers.dmidecode import DMIDecode
 from insights.parsers.cpuinfo import CpuInfo
 from insights.parsers.date import DateUTC
+from insights.parsers.installed_product_ids import InstalledProductIDs
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.parsers.lsmod import LsMod
 from insights.parsers.meminfo import MemInfo
@@ -38,10 +39,12 @@ SATELLITE_MANAGED_FILES = {
 
 @rule(optional=[Specs.hostname, CpuInfo, VirtWhat, MemInfo, IpAddr, DMIDecode,
                 RedHatRelease, Uname, LsMod, InstalledRpms, UnitFiles, PsAuxcww,
-                DateUTC, Uptime, YumReposD, LsEtc, CloudProvider, Specs.display_name, Specs.version_info])
+                DateUTC, Uptime, YumReposD, LsEtc, CloudProvider, Specs.display_name, Specs.version_info,
+                InstalledProductIDs])
 def system_profile(hostname, cpu_info, virt_what, meminfo, ip_addr, dmidecode,
                    redhat_release, uname, lsmod, installed_rpms, unit_files, ps_auxcww,
-                   date_utc, uptime, yum_repos_d, ls_etc, cloud_provider, display_name, version_info):
+                   date_utc, uptime, yum_repos_d, ls_etc, cloud_provider, display_name, version_info,
+                   product_ids):
     """
     This method applies parsers to a host and returns a system profile that can
     be sent to inventory service.
@@ -142,6 +145,9 @@ def system_profile(hostname, cpu_info, virt_what, meminfo, ip_addr, dmidecode,
         version_info_json = json.loads(version_info.content[0])
         profile['insights_client_version'] = version_info_json['client_version']
         profile['insights_egg_version'] = version_info_json['core_version']
+
+    if product_ids:
+        profile['installed_products'] = [{'id': product_id} for product_id in product_ids.ids]
 
     metadata_response = make_metadata()
     profile_sans_none = _remove_empties(profile)


### PR DESCRIPTION
To test...

If not running on a RHEL machine, install subscription-manager and put
product certificates in either /etc/pki/product or /etc/pki/product-default.
You can pull some from https://access.redhat.com/labs/rhpc/

As root:

```bash
pipenv shell
pipenv sync
pipenv install git+https://github.com/RedHatInsights/insights-core#egg=insights-core  # install updated master version of insights-core
insights-run -p pup.utils.fact_extract
```

Observe with the last command a line such as

```
    installed_products   : [{'id': '69'}, {'id': '487'}]
```

- `installed_products` in the swagger spec: https://github.com/RedHatInsights/insights-host-inventory/blob/4b377d01559b22e374341c9cb15454a3dff61087/swagger/api.spec.yaml#L864-L867
- `InstalledProduct` schema: https://github.com/RedHatInsights/insights-host-inventory/blob/4b377d01559b22e374341c9cb15454a3dff61087/swagger/api.spec.yaml#L720-L739